### PR TITLE
Bugfix/networking

### DIFF
--- a/collectd-docker.py
+++ b/collectd-docker.py
@@ -311,14 +311,14 @@ def build_network_stats_for(stats):
     stats['networks'] = network_stats
 
 def build_blkio_stats_for(stats):
-  blkio_stats = {}
-  for key, val in stats['blkio_stats'].iteritems():
-    tmp = {}
-    for op in val:
-      tmp[op.get('op').lower()] = op.get('value')
-    blkio_stats[key] = tmp
-  stats['blkio_stats'] = {}
-  stats['blkio_stats'] = blkio_stats
+    blkio_stats = {}
+    for key, val in stats['blkio_stats'].iteritems():
+        tmp = {}
+        for op in val:
+            tmp[op.get('op').lower()] = op.get('value')
+        blkio_stats[key] = tmp
+    stats['blkio_stats'] = {}
+    stats['blkio_stats'] = blkio_stats
 
 def format_stats(stats):
     build_blkio_stats_for(stats)

--- a/collectd-docker.py
+++ b/collectd-docker.py
@@ -320,6 +320,10 @@ def build_blkio_stats_for(stats):
   stats['blkio_stats'] = {}
   stats['blkio_stats'] = blkio_stats
 
+def format_stats(stats):
+    build_blkio_stats_for(stats)
+    build_network_stats_for(stats)
+
 def compile_regex(list):
     regexes = []
     for l in list:
@@ -347,8 +351,7 @@ while True:
         for id in find_containers():
             try:
                 stats = gather_stats(id)
-                build_blkio_stats_for(stats)
-                build_network_stats_for(stats)
+                format_stats(stats)
                 for i in flatten(stats, key=id[0:12], path='docker-librato').items():
                     blacklisted = False
                     for r in blacklist:

--- a/stats.json
+++ b/stats.json
@@ -1,14 +1,26 @@
 {
   "read":"2015-01-08T22:57:31.547920715Z",
-  "network":{
-    "rx_dropped":0,
-    "rx_bytes":648,
-    "rx_errors":0,
-    "tx_packets":8,
-    "tx_dropped":0,
-    "rx_packets":8,
-    "tx_errors":0,
-    "tx_bytes":648
+  "networks": {
+    "eth0": {
+      "rx_bytes": 5338,
+      "rx_dropped": 0,
+      "rx_errors": 0,
+      "rx_packets": 36,
+      "tx_bytes": 648,
+      "tx_dropped": 0,
+      "tx_errors": 0,
+      "tx_packets": 8
+    },
+    "eth5": {
+      "rx_bytes": 4641,
+      "rx_dropped": 0,
+      "rx_errors": 0,
+      "rx_packets": 26,
+      "tx_bytes": 690,
+      "tx_dropped": 0,
+      "tx_errors": 0,
+      "tx_packets": 9
+    }
   },
   "memory_stats":{
     "stats":{


### PR DESCRIPTION
Bugfix for network stats. [Docker Remote API v1.21](https://docs.docker.com/engine/reference/api/docker_remote_api/#v1-21-api-changes) introduced the following breaking change:

> GET /containers/(id)/stats will return networking information respectively for each interface.

Builds aggregated network stats for all network interfaces from new `"networks"` key. Maintains legacy metric namespace (`librato.docker.network`) to prevent any breaking changes to existing dashboards.

```
vagrant@vagrant-ubuntu-trusty-64:/opt/collectd/share/collectd$ sudo python collectd-docker.py
PUTVAL "localhost/docker-librato-32527f55f619/network-rx_dropped" interval=60 N:0
PUTVAL "localhost/docker-librato-32527f55f619/network-rx_errors" interval=60 N:0
PUTVAL "localhost/docker-librato-32527f55f619/network-tx_errors" interval=60 N:0
PUTVAL "localhost/docker-librato-32527f55f619/network-tx_dropped" interval=60 N:0
PUTVAL "localhost/docker-librato-32527f55f619/network-rx_packets" interval=60 N:16
PUTVAL "localhost/docker-librato-32527f55f619/network-tx_packets" interval=60 N:8
PUTVAL "localhost/docker-librato-32527f55f619/network-tx_bytes" interval=60 N:648
PUTVAL "localhost/docker-librato-32527f55f619/network-rx_bytes" interval=60 N:1296
```

![screenshot](http://i.imgur.com/eBmgyNB.png)
