### PR TITLE
Global info stats

### DIFF
--- a/collectd-docker.py
+++ b/collectd-docker.py
@@ -405,6 +405,25 @@ def collectd_output(metric, value):
     fmt_metric = metric.replace('.', '/')
     return "PUTVAL \"%s/%s\" interval=%s N:%s" % (HOSTNAME, fmt_metric, INTERVAL, value)
 
+def submit_values(stats, container_id=''):
+    try:
+        whitelist = compile_regex(WHITELIST_STATS)
+        blacklist = compile_regex(BLACKLIST_STATS)
+        for i in flatten(stats, key=container_id, path='docker-librato').items():
+            blacklisted = False
+            for r in blacklist:
+                if r.match(i[0].encode('ascii')):
+                    blacklisted = True
+                    break
+            if blacklisted == False:
+                for r in whitelist:
+                    metric = i[0].encode('ascii')
+                    if r.match(metric):
+                        print collectd_output(prettify_name(metric), i[1])
+                        break
+    except:
+        sys.exit(1)
+
 while True:
     try:
         whitelist = compile_regex(WHITELIST_STATS)

--- a/collectd-docker.py
+++ b/collectd-docker.py
@@ -396,6 +396,9 @@ def prettify_name(metric):
     prefix = '-'.join(metric.split('.')[0:2])
     suffix = '.'.join(metric.split('.')[2:])
 
+    if prefix == "docker-librato-global":
+        prefix = "docker" # plugin_instance is optional
+
     try:
         # strip off the docker.<id> prefix and look for our metric
         if METRICS_MAP[suffix]['name']:


### PR DESCRIPTION
Reduce sources for `librato.docker.containers.*` and `librato.docker.images.*` metrics by submitting global `/info` stats with `hostname` as source instead of `hostname.container_id`. Addresses https://github.com/librato/librato-collectd-docker/pull/7#issuecomment-190489499. Hack removes optional `plugin_instance` when `container_id` is not required for the source.

![docker](https://cloud.githubusercontent.com/assets/6326742/13472273/f6d28652-e068-11e5-8c16-c68cfda75ae8.png)
